### PR TITLE
Change check_certificate response

### DIFF
--- a/API.md
+++ b/API.md
@@ -321,9 +321,9 @@ The response looks like this:
 
     {
         "check_certificate": {
-            "data": [
+            "data": {
                 "is_valid": true
-            ],
+            },
             "ok": true
         }
     }


### PR DESCRIPTION
The check_certificate currently returns the following response:
{"check_certificate":{"ok":true,"data":{"data":{"is_valid":true}}}}
The response does not match the documentation.

Furthermore, the response described in the documentation is not a valid JSON (mixing array and object).