### PR TITLE
Add essential info to CLIENT_COMPAT

### DIFF
--- a/CLIENT_COMPAT.md
+++ b/CLIENT_COMPAT.md
@@ -166,6 +166,18 @@ Then install/update the relevant package:
 This will upgrade all required packages as well. You may need to reboot or 
 restart NetworkManager.
 
+### Configuration
+
+Find your country in the [list of eduVPN servers](https://status.eduvpn.org/)
+and download a configuration file from the server. If you want to use an
+eduVPN server in a different country, you have to use the official
+[eduvpn-client](https://python-eduvpn-client.readthedocs.io/en/master/) as
+international authentication is currently only available through the API.
+
+To import the resulting ovpn file into NetworkManager, use the `nmcli` command:
+
+    $ nmcli conn import type openvpn file eduVPN_institute.ovpn
+
 ### Split Tunnel
 
 If you do _not_ want to route all traffic over the VPN, you need to manually


### PR DESCRIPTION
It took me ages to find out where to get the ovpn config file for my eduVPN connection, and some more searching for a way to import it into NetworkManager. Given that this is something each individual user has to do, I thought it should be a little more obvious.

Is it truly impossible to download a config file for a different country with just a browser? Perhaps servers would need a different WAYF that lets one choose countries first?

Info for Debian 8 / Ubuntu 16.04 is probably obsolete by now, and I doubt there are a lot of new client installations on Debian 9 / Ubuntu 18.04 even...