### PR TITLE
Bring setup of admin account in line with docs

### DIFF
--- a/DEVELOPMENT_SETUP.md
+++ b/DEVELOPMENT_SETUP.md
@@ -72,8 +72,8 @@ to easily test the portals.
 Now with your browser you can connect to the user portal on 
 `http://localhost:8082/`.
 
-You can login with the users `foo` and password `bar` or `admin` with password 
-`secret`.
+You can login with the users `foo` and password `bar` (user account) or `admin`
+with password `secret` (administrator account).
 
 # VPN Server Configuration
 

--- a/DEVELOPMENT_SETUP.md
+++ b/DEVELOPMENT_SETUP.md
@@ -72,7 +72,7 @@ to easily test the portals.
 Now with your browser you can connect to the user portal on 
 `http://localhost:8082/`.
 
-You can login with the users `foo` and password `bar` (user account) or `admin`
+You can login with the users `foo` with password `bar` (user account) or `admin`
 with password `secret` (administrator account).
 
 # VPN Server Configuration

--- a/development_setup.sh
+++ b/development_setup.sh
@@ -46,13 +46,14 @@ cat << EOF > config/config.php
 \$localConfig = [
     //'styleName' => 'eduVPN',
     //'styleName' => 'LC',
-    'adminUserIdList' => ['foo'],
+    'adminUserIdList' => ['admin', 'foo'],
     'vpnCaPath' => '${BASE_DIR}/vpn-ca/vpn-ca',
 ];
 return array_merge(\$baseConfig, \$localConfig);
 EOF
 
 php libexec/generate-secrets.php
+php bin/account.php --add admin --password secret
 php bin/account.php --add foo --password bar
 
 # symlink to the official templates we have so we can easily modify and test

--- a/development_setup.sh
+++ b/development_setup.sh
@@ -46,7 +46,7 @@ cat << EOF > config/config.php
 \$localConfig = [
     //'styleName' => 'eduVPN',
     //'styleName' => 'LC',
-    'adminUserIdList' => ['admin', 'foo'],
+    'adminUserIdList' => ['admin'],
     'vpnCaPath' => '${BASE_DIR}/vpn-ca/vpn-ca',
 ];
 return array_merge(\$baseConfig, \$localConfig);


### PR DESCRIPTION
The development setup documentation states:
```
You can login with the users foo and password bar or admin with password secret.
```
 However, after running the setup, I only had the user "foo" to work with.
This change adds the creation of user "admin" during the setup.

Another option would have been to change the document. Remove the user "admin" and only mention the user "foo". However, having two users seems like the better solution to me.